### PR TITLE
Randomize items and other item improvements

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
@@ -40,7 +40,7 @@ public class CustomModelDataPoly implements ItemPoly {
     protected final int CMDvalue;
 
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base) {
-        Pair<Item,Integer> pair = registerManager.RequestCMDwithItem();
+        Pair<Item,Integer> pair = registerManager.requestCMDwithItem();
         CMDvalue = pair.getRight();
         defaultServerItem = new ItemStack(pair.getLeft());
         CompoundTag tag = new CompoundTag();
@@ -56,7 +56,7 @@ public class CustomModelDataPoly implements ItemPoly {
      * @param target          the serverside item will be of this type
      */
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base, Item target) {
-        CMDvalue = registerManager.RequestCMDValue(target);
+        CMDvalue = registerManager.requestCMDValue(target);
         defaultServerItem = new ItemStack(target);
         CompoundTag tag = new CompoundTag();
         tag.putInt("CustomModelData", CMDvalue);

--- a/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
@@ -60,7 +60,7 @@ public class CustomModelDataPoly implements ItemPoly {
      * @param targets         the serverside items that can be chosen from
      */
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base, Item[] targets) {
-        Pair<Item,Integer> pair = registerManager.requestCMD();
+        Pair<Item,Integer> pair = registerManager.requestCMD(targets);
         CMDvalue = pair.getRight();
         defaultServerItem = new ItemStack(pair.getLeft());
         CompoundTag tag = new CompoundTag();

--- a/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
@@ -40,7 +40,7 @@ public class CustomModelDataPoly implements ItemPoly {
     protected final int CMDvalue;
 
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base) {
-        Pair<Item,Integer> pair = registerManager.requestCMDwithItem();
+        Pair<Item,Integer> pair = registerManager.requestCMD();
         CMDvalue = pair.getRight();
         defaultServerItem = new ItemStack(pair.getLeft());
         CompoundTag tag = new CompoundTag();
@@ -56,7 +56,7 @@ public class CustomModelDataPoly implements ItemPoly {
      * @param target          the serverside item will be of this type
      */
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base, Item target) {
-        CMDvalue = registerManager.requestCMDValue(target);
+        CMDvalue = registerManager.requestCMD(target);
         defaultServerItem = new ItemStack(target);
         CompoundTag tag = new CompoundTag();
         tag.putInt("CustomModelData", CMDvalue);

--- a/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataPoly.java
@@ -40,13 +40,7 @@ public class CustomModelDataPoly implements ItemPoly {
     protected final int CMDvalue;
 
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base) {
-        Pair<Item,Integer> pair = registerManager.requestCMD();
-        CMDvalue = pair.getRight();
-        defaultServerItem = new ItemStack(pair.getLeft());
-        CompoundTag tag = new CompoundTag();
-        tag.putInt("CustomModelData", CMDvalue);
-        defaultServerItem.setTag(tag);
-        defaultServerItem.setCustomName(new TranslatableText(base.getTranslationKey()).setStyle(Style.EMPTY.withItalic(false)));
+        this(registerManager, base, CustomModelDataManager.DEFAULT_ITEMS);
     }
 
     /**
@@ -56,8 +50,19 @@ public class CustomModelDataPoly implements ItemPoly {
      * @param target          the serverside item will be of this type
      */
     public CustomModelDataPoly(CustomModelDataManager registerManager, Item base, Item target) {
-        CMDvalue = registerManager.requestCMD(target);
-        defaultServerItem = new ItemStack(target);
+        this(registerManager, base, new Item[]{target});
+    }
+
+    /**
+     * Makes a poly that generates the specified item with a custom model data value
+     * If the item used doesn't matter it is recommended to use the more generic method instead
+     * @param registerManager manager used to generate the CMD value
+     * @param targets         the serverside items that can be chosen from
+     */
+    public CustomModelDataPoly(CustomModelDataManager registerManager, Item base, Item[] targets) {
+        Pair<Item,Integer> pair = registerManager.requestCMD();
+        CMDvalue = pair.getRight();
+        defaultServerItem = new ItemStack(pair.getLeft());
         CompoundTag tag = new CompoundTag();
         tag.putInt("CustomModelData", CMDvalue);
         defaultServerItem.setTag(tag);

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -68,7 +68,6 @@ public class CustomModelDataManager {
             Items.BREAD
     };
     public final static Item[] BLOCK_ITEMS = {
-            Items.BARRIER,
             Items.STRUCTURE_VOID
     };
 

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -56,15 +56,16 @@ public class CustomModelDataManager {
     };
 
     /**
-     * Request an amount of CMD values you need for a specific item. To prevent CMD values from conflicting
-     * If you don't specifically need this item it's recommended to use {@link #requestCMDwithItem}
-     * Example: you request 5 values for a carrot on a stick. You get the number 2 back. You can now use the values 2,3,4,5,6 in your code and resourcepack.
+     * Request a certain amount of CMD values from the specified item
      * @param item   the item you need CMD for
-     * @param amount the amount of CMD values you're requesting
+     * @param amount the amount of cmd values you need.
      * @return the first value you can use.
-     * @throws ArithmeticException if the limit of CustomModelData is reached
+     *         Example: you passed in 5 as amount. You got 9 back as value. You can now use 9,10,11,12 and 13
+     * @deprecated it is recommended to use multiple items. As to minimize recipe weirdness.
+     * @throws ArithmeticException if {@link Integer#MAX_VALUE} is reached.
      */
-    public int requestCMDValue(Item item, int amount) throws ArithmeticException {
+    @Deprecated
+    public int requestCMD(Item item, int amount) throws ArithmeticException {
         int current = customModelDataCounter.getInt(item); //this is the current CMD that we're at for this item/
         if (current == 0) {
             current = 1; //we should start at 1. Never 0
@@ -75,32 +76,32 @@ public class CustomModelDataManager {
     }
 
     /**
-     * Request 1 CMD value for a specific item. To prevent CMD values from conflicting
-     * Example: you request 1 CMD value for a carrot on a stick. You get the number 5 back. You can now use that number in your code and resourcepacks.
+     * Request one CMD value for a specific item.
      * @param item the item you need CMD for
      * @return the value you can use.
+     * @deprecated it is recommended to use multiple items. As to minimize recipe weirdness.
      */
-    public int requestCMDValue(Item item) {
-        return requestCMDValue(item, 1);
+    @Deprecated
+    public int requestCMD(Item item) {
+        return requestCMD(item, 1);
     }
 
     /**
-     * Request an amount of CustomModelData values. To prevent CMD values from conflicting.
-     * This will also allocate an item, in case we run out of CMD values on one item.
-     * Example: you request 5 values. You get the number 2 and "stick" back. You can now use sticks with CMD values 2,3,4,5 and 6 in your code and resourcepack.
-     * Items that will be used are in {@link #DEFAULT_ITEMS}
-     * @param amount amount of CMD values you'd like to allocate
-     * @return the first number you can use and for which item that is.
-     * @throws ArithmeticException if there have been a rediculous amount of CMD values allocated
+     * Requests a certain amount of items from the specified array.
+     * @param items  the list of items to choose from.
+     * @param amount the amount of cmd values you need.
+     * @return the item you may use and the CMD value. The CMD value returned is the first you may use, the rest can be derived.
+     *         Example: you passed in 5 as amount. You got 9 back as value. You can now use 9,10,11,12 and 13
+     * @throws ArithmeticException if a ridiculous amount of CMD values has been reached.
      */
-    public Pair<Item,Integer> requestCMDwithItem(int amount) {
+    public Pair<Item,Integer> requestCMD(Item[] items, int amount) {
         int startingRR = roundRobin;
         do {
             roundRobin++;
 
             try {
-                int value = requestCMDValue(DEFAULT_ITEMS[roundRobin], amount);
-                return new Pair<>(DEFAULT_ITEMS[roundRobin], value);
+                Item item = getRoundRobin(items);
+                return new Pair<>(item, requestCMD(item, amount));
             } catch (ArithmeticException ignored) {}
         } while (roundRobin != startingRR);
 
@@ -108,13 +109,35 @@ public class CustomModelDataManager {
     }
 
     /**
-     * Request an item with a CustomModelData. To prevent CMD values from conflicting.
-     * This will also allocate an item, in case we run out of CMD values on one item
-     * Example: you request an item. You get the number 5 and the Glistering water melon slice item back. You can now use glistering water melon slices with CMD of 5 in your code and resourcepack
-     * Items that will be used are in {@link #DEFAULT_ITEMS}
-     * @return the number you can use and for which item.
+     * Requests a certain amount of CMD values.
+     * This will use the {@link #DEFAULT_ITEMS} array.
+     * @param amount the amount of cmd values you need.
+     * @return the item you may use and the CMD value. The CMD value returned is the first you may use, the rest can be derived.
+     *         Example: you passed in 5 as amount. You got 9 back as value. You can now use 9,10,11,12 and 13
      */
-    public Pair<Item,Integer> requestCMDwithItem() {
-        return requestCMDwithItem(1);
+    public Pair<Item,Integer> requestCMD(int amount) {
+        return requestCMD(DEFAULT_ITEMS, amount);
+    }
+
+    /**
+     * Request an item with a CustomModelData. To prevent CMD values from conflicting.
+     * @param items the list of items to choose from.
+     * @return the item you may use and the CMD value
+     */
+    public Pair<Item,Integer> requestCMD(Item[] items) {
+        return requestCMD(items, 1);
+    }
+
+    /**
+     * Requests a single CMD value.
+     * This will use the {@link #DEFAULT_ITEMS} array
+     * @return the item you may use and the CMD value
+     */
+    public Pair<Item,Integer> requestCMD() {
+        return requestCMD(DEFAULT_ITEMS, 1);
+    }
+
+    private Item getRoundRobin(Item[] list) {
+        return list[roundRobin % list.length];
     }
 }

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -29,14 +29,25 @@ import net.minecraft.util.Pair;
  */
 public class CustomModelDataManager {
     private final Object2IntMap<Item> CustomModelDataCurrent = new Object2IntOpenHashMap<>();
-    private final Item[] DEFAULT_ITEMS = {
+    private int roundRobin = 0;
+    public final Item[] DEFAULT_ITEMS = {
             Items.STICK,
             Items.GLISTERING_MELON_SLICE,
             Items.EMERALD,
             Items.IRON_NUGGET,
             Items.GOLD_NUGGET,
             Items.GOLD_INGOT,
-            Items.NETHER_STAR
+            Items.DIRT,
+            Items.BRAIN_CORAL,
+            Items.BUBBLE_CORAL,
+            Items.FIRE_CORAL,
+            Items.HORN_CORAL,
+            Items.TUBE_CORAL,
+            Items.DEAD_BRAIN_CORAL,
+            Items.DEAD_BUBBLE_CORAL,
+            Items.DEAD_FIRE_CORAL,
+            Items.DEAD_HORN_CORAL,
+            Items.DEAD_TUBE_CORAL
     };
 
     /**
@@ -78,13 +89,17 @@ public class CustomModelDataManager {
      * @throws ArithmeticException if there have been a rediculous amount of CMD values allocated
      */
     public Pair<Item,Integer> RequestCMDwithItem(int amount) {
-        for (Item item : DEFAULT_ITEMS) {
+        int startingRR = roundRobin;
+        do {
+            roundRobin++;
+
             try {
-                int value = RequestCMDValue(item, amount);
-                return new Pair<>(item, value);
+                int value = RequestCMDValue(DEFAULT_ITEMS[roundRobin], amount);
+                return new Pair<>(DEFAULT_ITEMS[roundRobin], value);
             } catch (ArithmeticException ignored) {}
-        }
-        throw new ArithmeticException("Reached limit off CustomModelData items!");
+        } while (roundRobin != startingRR);
+
+        throw new ArithmeticException("Reached limit of CustomModelData items");
     }
 
     /**

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -28,7 +28,7 @@ import net.minecraft.util.Pair;
  * For example, a mod can request 100 CustomModelData values for a specific item. Then those will be reserved and another mod will get different values
  */
 public class CustomModelDataManager {
-    private final Object2IntMap<Item> CustomModelDataCurrent = new Object2IntOpenHashMap<>();
+    private final Object2IntMap<Item> customModelDataCounter = new Object2IntOpenHashMap<>();
     private int roundRobin = 0;
     public final Item[] DEFAULT_ITEMS = {
             Items.STICK,
@@ -57,20 +57,20 @@ public class CustomModelDataManager {
 
     /**
      * Request an amount of CMD values you need for a specific item. To prevent CMD values from conflicting
-     * If you don't specifically need this item it's recommended to use {@link #RequestCMDwithItem}
+     * If you don't specifically need this item it's recommended to use {@link #requestCMDwithItem}
      * Example: you request 5 values for a carrot on a stick. You get the number 2 back. You can now use the values 2,3,4,5,6 in your code and resourcepack.
      * @param item   the item you need CMD for
      * @param amount the amount of CMD values you're requesting
      * @return the first value you can use.
      * @throws ArithmeticException if the limit of CustomModelData is reached
      */
-    public int RequestCMDValue(Item item, int amount) throws ArithmeticException {
-        int current = CustomModelDataCurrent.getInt(item); //this is the current CMD that we're at for this item/
+    public int requestCMDValue(Item item, int amount) throws ArithmeticException {
+        int current = customModelDataCounter.getInt(item); //this is the current CMD that we're at for this item/
         if (current == 0) {
             current = 1; //we should start at 1. Never 0
         }
         int newValue = Math.addExact(current, amount);
-        CustomModelDataCurrent.put(item, newValue);
+        customModelDataCounter.put(item, newValue);
         return current;
     }
 
@@ -80,8 +80,8 @@ public class CustomModelDataManager {
      * @param item the item you need CMD for
      * @return the value you can use.
      */
-    public int RequestCMDValue(Item item) {
-        return RequestCMDValue(item, 1);
+    public int requestCMDValue(Item item) {
+        return requestCMDValue(item, 1);
     }
 
     /**
@@ -93,13 +93,13 @@ public class CustomModelDataManager {
      * @return the first number you can use and for which item that is.
      * @throws ArithmeticException if there have been a rediculous amount of CMD values allocated
      */
-    public Pair<Item,Integer> RequestCMDwithItem(int amount) {
+    public Pair<Item,Integer> requestCMDwithItem(int amount) {
         int startingRR = roundRobin;
         do {
             roundRobin++;
 
             try {
-                int value = RequestCMDValue(DEFAULT_ITEMS[roundRobin], amount);
+                int value = requestCMDValue(DEFAULT_ITEMS[roundRobin], amount);
                 return new Pair<>(DEFAULT_ITEMS[roundRobin], value);
             } catch (ArithmeticException ignored) {}
         } while (roundRobin != startingRR);
@@ -114,7 +114,7 @@ public class CustomModelDataManager {
      * Items that will be used are in {@link #DEFAULT_ITEMS}
      * @return the number you can use and for which item.
      */
-    public Pair<Item,Integer> RequestCMDwithItem() {
-        return RequestCMDwithItem(1);
+    public Pair<Item,Integer> requestCMDwithItem() {
+        return requestCMDwithItem(1);
     }
 }

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -38,21 +38,11 @@ public class CustomModelDataManager {
             Items.GOLD_NUGGET,
             Items.GOLD_INGOT,
             Items.NETHERITE_INGOT,
-            Items.DIRT,
-            Items.BRAIN_CORAL,
-            Items.BUBBLE_CORAL,
-            Items.FIRE_CORAL,
-            Items.HORN_CORAL,
-            Items.TUBE_CORAL,
-            Items.DEAD_BRAIN_CORAL,
-            Items.DEAD_BUBBLE_CORAL,
-            Items.DEAD_FIRE_CORAL,
-            Items.DEAD_HORN_CORAL,
-            Items.DEAD_TUBE_CORAL,
             Items.HEART_OF_THE_SEA,
             Items.PHANTOM_MEMBRANE,
             Items.BLAZE_POWDER,
-            Items.BLAZE_ROD
+            Items.BLAZE_ROD,
+            Items.PAPER
     };
     public final static Item[] FOOD_ITEMS = {
             Items.COOKED_BEEF,

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -37,6 +37,7 @@ public class CustomModelDataManager {
             Items.IRON_NUGGET,
             Items.GOLD_NUGGET,
             Items.GOLD_INGOT,
+            Items.NETHERITE_INGOT,
             Items.DIRT,
             Items.BRAIN_CORAL,
             Items.BUBBLE_CORAL,
@@ -47,7 +48,11 @@ public class CustomModelDataManager {
             Items.DEAD_BUBBLE_CORAL,
             Items.DEAD_FIRE_CORAL,
             Items.DEAD_HORN_CORAL,
-            Items.DEAD_TUBE_CORAL
+            Items.DEAD_TUBE_CORAL,
+            Items.HEART_OF_THE_SEA,
+            Items.PHANTOM_MEMBRANE,
+            Items.BLAZE_POWDER,
+            Items.BLAZE_ROD
     };
 
     /**

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -30,7 +30,7 @@ import net.minecraft.util.Pair;
 public class CustomModelDataManager {
     private final Object2IntMap<Item> customModelDataCounter = new Object2IntOpenHashMap<>();
     private int roundRobin = 0;
-    public final Item[] DEFAULT_ITEMS = {
+    public final static Item[] DEFAULT_ITEMS = {
             Items.STICK,
             Items.GLISTERING_MELON_SLICE,
             Items.EMERALD,
@@ -53,6 +53,29 @@ public class CustomModelDataManager {
             Items.PHANTOM_MEMBRANE,
             Items.BLAZE_POWDER,
             Items.BLAZE_ROD
+    };
+    public final static Item[] FOOD_ITEMS = {
+            Items.COOKED_BEEF,
+            Items.COOKED_CHICKEN,
+            Items.COOKED_COD,
+            Items.COOKED_MUTTON,
+            Items.COOKED_PORKCHOP,
+            Items.COOKED_RABBIT,
+            Items.COOKED_SALMON,
+            Items.BEEF,
+            Items.CHICKEN,
+            Items.COD,
+            Items.MUTTON,
+            Items.PORKCHOP,
+            Items.RABBIT,
+            Items.SALMON,
+            Items.CARROT,
+            Items.GOLDEN_CARROT,
+            Items.APPLE,
+            Items.BEETROOT,
+            Items.POTATO,
+            Items.BAKED_POTATO,
+            Items.BREAD
     };
 
     /**

--- a/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/register/CustomModelDataManager.java
@@ -67,6 +67,10 @@ public class CustomModelDataManager {
             Items.BAKED_POTATO,
             Items.BREAD
     };
+    public final static Item[] BLOCK_ITEMS = {
+            Items.BARRIER,
+            Items.STRUCTURE_VOID
+    };
 
     /**
      * Request a certain amount of CMD values from the specified item

--- a/src/main/java/io/github/theepicblock/polymc/generator/ItemPolyGenerator.java
+++ b/src/main/java/io/github/theepicblock/polymc/generator/ItemPolyGenerator.java
@@ -73,6 +73,9 @@ public class ItemPolyGenerator {
         if (item instanceof DyeableItem) {
             return new CustomModelDataPoly(builder.getCMDManager(), item, Items.LEATHER_HORSE_ARMOR);
         }
+        if (item instanceof BlockItem) {
+            return new CustomModelDataPoly(builder.getCMDManager(), item, CustomModelDataManager.BLOCK_ITEMS);
+        }
         return new CustomModelDataPoly(builder.getCMDManager(), item);
     }
 

--- a/src/main/java/io/github/theepicblock/polymc/generator/ItemPolyGenerator.java
+++ b/src/main/java/io/github/theepicblock/polymc/generator/ItemPolyGenerator.java
@@ -19,6 +19,7 @@ package io.github.theepicblock.polymc.generator;
 
 import io.github.theepicblock.polymc.Util;
 import io.github.theepicblock.polymc.api.item.*;
+import io.github.theepicblock.polymc.api.register.CustomModelDataManager;
 import io.github.theepicblock.polymc.api.register.PolyRegistry;
 import net.minecraft.item.*;
 import net.minecraft.util.Identifier;
@@ -67,7 +68,7 @@ public class ItemPolyGenerator {
             return new DamageableItemPoly(builder.getCMDManager(), item);
         }
         if (item.isFood()) {
-            return new CustomModelDataPoly(builder.getCMDManager(), item, Items.COOKED_BEEF);
+            return new CustomModelDataPoly(builder.getCMDManager(), item, CustomModelDataManager.FOOD_ITEMS);
         }
         if (item instanceof DyeableItem) {
             return new CustomModelDataPoly(builder.getCMDManager(), item, Items.LEATHER_HORSE_ARMOR);


### PR DESCRIPTION
closes #40 by implementing the idea discussed there. Items will now choose out of a pool of items. Minimizing the risks of recipes conflicting. Besides that, this pr also cleans up a lot of the CMD code and makes blocks use structure voids.