### PR TITLE
Fix NPE that occurs when Minecraft attempts to set a block in an empty chunk section

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/context/WorldChunkMixin.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/context/WorldChunkMixin.java
@@ -39,7 +39,10 @@ public class WorldChunkMixin {
     @Inject(method = "setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Z)Lnet/minecraft/block/BlockState;",
             at = @At("RETURN")) //TODO this can be better
     public void setChunkWorld(BlockPos pos, BlockState state, boolean moved, CallbackInfoReturnable<BlockState> cir) {
-        ((WorldProvider)sections[pos.getY() >> 4]).polyMcSetWorld(this.world);
+        ChunkSection chunkSection = sections[pos.getY() >> 4];
+        if(chunkSection != null) {
+            ((WorldProvider)chunkSection).polyMcSetWorld(this.world);
+        }
     }
 
     @Inject(method = "<init>(Lnet/minecraft/world/World;Lnet/minecraft/util/math/ChunkPos;Lnet/minecraft/world/biome/source/BiomeArray;Lnet/minecraft/world/chunk/UpgradeData;Lnet/minecraft/world/TickScheduler;Lnet/minecraft/world/TickScheduler;J[Lnet/minecraft/world/chunk/ChunkSection;Ljava/util/function/Consumer;)V", at = @At("RETURN"))


### PR DESCRIPTION
I came across this error in a custom 20w46a build of PolyMC, but this bug most likely also occurs in 1.16.4. It seems to be caused by Minecraft attempting to spawn a structure in a chunk section that hasn't been generated yet.