### PR TITLE
Always get the ItemStack name + make sure the custom name is not in i…

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
@@ -82,12 +82,11 @@ public class CustomModelDataPoly implements ItemPoly {
 
         // Always set the name again in case the item can change its name based on NBT data
         if (!input.hasCustomName()) {
-
             BaseText name = (BaseText) input.getName();
 
             // Override the style to make sure the client does not render
-            // the custom name in italics
-            name.setStyle(name.getStyle().withItalic(false));
+            // the custom name in italics, and uses the correct rarity format
+            name.setStyle(name.getStyle().withItalic(false).withColor(input.getRarity().formatting));
 
             serverItem.setCustomName(name);
         }

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
@@ -25,8 +25,7 @@ import io.github.theepicblock.polymc.impl.Util;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.text.Style;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.*;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.registry.Registry;
@@ -79,10 +78,20 @@ public class CustomModelDataPoly implements ItemPoly {
             serverItem.setTag(input.getTag().copy());
             //doing this removes the CMD, so we should add that again
             serverItem.getTag().putInt("CustomModelData", CMDvalue);
-            if (!input.hasCustomName()) { //It might be that the tags didn't include the name, so we should add them back in
-                serverItem.setCustomName(defaultServerItem.getName());
-            }
         }
+
+        // Always set the name again in case the item can change its name based on NBT data
+        if (!input.hasCustomName()) {
+
+            BaseText name = (BaseText) input.getName();
+
+            // Override the style to make sure the client does not render
+            // the custom name in italics
+            name.setStyle(name.getStyle().withItalic(false));
+
+            serverItem.setCustomName(name);
+        }
+
         serverItem.setCount(input.getCount());
         serverItem.setCooldown(input.getCooldown());
         return serverItem;


### PR DESCRIPTION
First change:
Some items change their name based on their NBT data. (Like a PlayerHead)

This is why `defaultServerItem` ItemStack should not be used.
The `input` ItemStack should be used instead.

Second change:
The name was only updated within the `if (input.hasTag())` block, which is not always true.
Since `getName()` implementations can basically return a different name any time they choose, I think it should be executed each time the client needs the item.

Last change:
The item names always showed up in _italics_ on the client side, and it was driving me nuts.
That's been fixed.

I hope you'll find this useful. Let me know if I need to change anything here, I don't program in Java that much. (And I've only been programming for Fabric since a week)

Next thing I might want to tackle is the color of the items. Right now they use the color based on the rarity of the poly item.
So sometimes an item is purple, sometimes yellow, when it really shouldn't be.