### PR TITLE
Ensure `StaticSlot#getStack()` does not return null

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/gui/StaticSlot.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/gui/StaticSlot.java
@@ -51,7 +51,7 @@ public class StaticSlot extends Slot {
     }
 
     public ItemStack getStack() {
-        return this.stack;
+        return this.stack == null ? ItemStack.EMPTY : this.stack;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class StaticSlot extends Slot {
     }
 
     public int getMaxItemCount() {
-        return this.stack.getCount();
+        return this.getStack().getCount();
     }
 
     public int getMaxItemCount(ItemStack stack) {


### PR DESCRIPTION
Ledger has a mixin to keep track of changes to screen Slots, and it does `this.getStack().copy()` at the end of the Slot constructor.
But `StaticSlot` can only set its own stack after the constructor has run, so right now it always returns null and that crashes the server.

So small fix: just return an empty stack when the stack has not been set yet.