### PR TITLE
Add `PolyMap#getClientStateRawId()` to get a BlockState's client-side raw id

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/PolyMap.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/PolyMap.java
@@ -50,6 +50,14 @@ public interface PolyMap {
     }
 
     /**
+     * Get the RawId of the client-state block
+     */
+    default int getClientStateRawId(BlockState state, ServerPlayerEntity playerEntity) {
+        BlockState clientState = this.getClientBlock(state);
+        return Block.STATE_IDS.getRawId(clientState);
+    }
+
+    /**
      * Gets the {@link GuiPoly} that this PolyMap associates with this {@link ScreenHandlerType}.
      * @return A {@link GuiPoly} describing how to display this screen type on the client.
      */

--- a/src/main/java/io/github/theepicblock/polymc/impl/Util.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/Util.java
@@ -172,8 +172,7 @@ public class Util {
      */
     public static int getPolydRawIdFromState(BlockState state, ServerPlayerEntity playerEntity) {
         PolyMap map = PolyMapProvider.getPolyMap(playerEntity);
-        BlockState clientState = map.getClientBlock(state);
-        return Block.STATE_IDS.getRawId(clientState);
+        return map.getClientStateRawId(state, playerEntity);
     }
 
     /**


### PR DESCRIPTION
With this patch, looking up a client's raw BlockState id will always be done by the client's assigned PolyMap.
By default, this will still only do `Block.STATE_IDS.getRawId(clientState);`, but it allows other kind of PolyMaps to change this.

(I need this in order to get [skerit/polyvalent](https://github.com/skerit/polyvalent) working: it uses a few dummy-modded blocks as polys, but if the client has different mods loaded those client-side state ids will differ greatly from the server)