### PR TITLE
Restore the `PolyMap#getClientStateRawId` method

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/PolyMap.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/PolyMap.java
@@ -28,6 +28,7 @@ import io.github.theepicblock.polymc.mixins.gui.GuiPolyImplementation;
 import io.github.theepicblock.polymc.mixins.item.CreativeItemStackFix;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
@@ -50,6 +51,19 @@ public interface PolyMap {
         if (poly == null) return serverBlock;
 
         return poly.getClientBlock(serverBlock);
+    }
+
+    /**
+     * Get the raw id of the clientside blockstate.
+     */
+    default int getClientStateRawId(BlockState state, ServerPlayerEntity playerEntity) {
+        BlockState clientState = this.getClientState(state, playerEntity);
+
+        if (clientState == null) {
+            clientState = Blocks.STONE.getDefaultState();
+        }
+
+        return Block.STATE_IDS.getRawId(clientState);
     }
 
     /**

--- a/src/main/java/io/github/theepicblock/polymc/impl/Util.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/Util.java
@@ -194,7 +194,7 @@ public class Util {
      */
     public static int getPolydRawIdFromState(BlockState state, ServerPlayerEntity playerEntity) {
         PolyMap map = Util.tryGetPolyMap(playerEntity);
-        return Block.STATE_IDS.getRawId(map.getClientState(state, playerEntity));
+        return map.getClientStateRawId(state, playerEntity);
     }
 
     /**

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/IdListImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/IdListImplementation.java
@@ -70,6 +70,6 @@ public class IdListImplementation {
     @Unique
     private long transform(long in, PolyMap map, ServerPlayerEntity playerEntity) {
         var state = Block.getStateFromRawId((int)in);
-        return Block.STATE_IDS.getRawId(map.getClientState(state, playerEntity));
+        return map.getClientStateRawId(state, playerEntity);
     }
 }

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/PaletteBlockPolyImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/PaletteBlockPolyImplementation.java
@@ -45,7 +45,7 @@ public abstract class PaletteBlockPolyImplementation<T> {
 
             PolyMap map = Util.tryGetPolyMap(player);
             //noinspection unchecked
-            return Block.STATE_IDS.getRawId(map.getClientState((BlockState)object, player));
+            return map.getClientStateRawId((BlockState)object, player);
         }
 
         return instance.getRawId(object);

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
@@ -8,18 +8,20 @@ import net.minecraft.util.collection.IndexedIterable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import xyz.nucleoid.packettweaker.PacketContext;
 
 @Mixin(PacketByteBuf.class)
 public class WriteRegistryValueImplementation {
-    @ModifyVariable(method = "writeRegistryValue", at = @At("HEAD"), argsOnly = true)
-    private <T> T redirectBlock(T original, IndexedIterable<T> registry) {
+
+    @Redirect(method = "writeRegistryValue", at=@At(value="INVOKE", target="Lnet/minecraft/util/collection/IndexedIterable;getRawId(Ljava/lang/Object;)I"))
+    private <T> int redirectGetRawId(IndexedIterable<T> registry, T value) {
         if (registry == Block.STATE_IDS) {
             var player = PacketContext.get().getTarget();
             var polymap = Util.tryGetPolyMap(player);
-            //noinspection unchecked
-            return (T)polymap.getClientState((BlockState)original, player);
+            return polymap.getClientStateRawId((BlockState) value, player);
         }
-        return original;
+
+        return registry.getRawId(value);
     }
 }

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
@@ -8,7 +8,6 @@ import net.minecraft.util.collection.IndexedIterable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import xyz.nucleoid.packettweaker.PacketContext;
 
 @Mixin(PacketByteBuf.class)
@@ -22,7 +21,7 @@ public class WriteRegistryValueImplementation {
             int clientStateId = polymap.getClientStateRawId((BlockState)original, player);
 
             //noinspection unchecked
-            return (T) Block.STATE_IDS.get(clientStateId);
+            return (T)Block.STATE_IDS.get(clientStateId);
         }
         return original;
     }

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/implementations/WriteRegistryValueImplementation.java
@@ -14,14 +14,16 @@ import xyz.nucleoid.packettweaker.PacketContext;
 @Mixin(PacketByteBuf.class)
 public class WriteRegistryValueImplementation {
 
-    @Redirect(method = "writeRegistryValue", at=@At(value="INVOKE", target="Lnet/minecraft/util/collection/IndexedIterable;getRawId(Ljava/lang/Object;)I"))
-    private <T> int redirectGetRawId(IndexedIterable<T> registry, T value) {
+    @ModifyVariable(method = "writeRegistryValue", at = @At("HEAD"), argsOnly = true)
+    private <T> T redirectBlock(T original, IndexedIterable<T> registry) {
         if (registry == Block.STATE_IDS) {
             var player = PacketContext.get().getTarget();
             var polymap = Util.tryGetPolyMap(player);
-            return polymap.getClientStateRawId((BlockState) value, player);
-        }
+            int clientStateId = polymap.getClientStateRawId((BlockState)original, player);
 
-        return registry.getRawId(value);
+            //noinspection unchecked
+            return (T) Block.STATE_IDS.get(clientStateId);
+        }
+        return original;
     }
 }


### PR DESCRIPTION
By making the PolyMap responsible for converting the clientstate into a valid raw id I can do my Polyvalent magic.
Added an extra null check just in case there's ever a polymap that doesn't behave :shrug: 