### PR TITLE
Use TreeMap instead of HashMap to get identical resourcepack outputs

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/impl/PolyMapImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/PolyMapImpl.java
@@ -56,9 +56,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 /**
  * This is the standard implementation of the PolyMap that PolyMc uses by default.
@@ -212,7 +210,7 @@ public class PolyMapImpl implements PolyMap {
         });
 
         // Import the language files for all mods
-        var languageKeys = new HashMap<String,HashMap<String, String>>(); // The first hashmap is per-language. Then it's translationkey->translation
+        var languageKeys = new TreeMap<String, Map<String, String>>(); // The first hashmap is per-language. Then it's translationkey->translation
         for (var lang : moddedResources.locateLanguageFiles()) {
             // Ignore fapi
             if (lang.getNamespace().equals("fabric")) continue;
@@ -220,7 +218,7 @@ public class PolyMapImpl implements PolyMap {
                 try (var streamReader = new InputStreamReader(stream, StandardCharsets.UTF_8)){
                     // Copy all of the language keys into the main map
                     var languageObject = pack.getGson().fromJson(streamReader, JsonObject.class);
-                    var mainLangMap = languageKeys.computeIfAbsent(lang.getPath(), (key) -> new HashMap<>());
+                    var mainLangMap = languageKeys.computeIfAbsent(lang.getPath(), (key) -> new TreeMap<>());
                     languageObject.entrySet().forEach(entry -> mainLangMap.put(entry.getKey(), JsonHelper.asString(entry.getValue(), entry.getKey())));
                 } catch (JsonParseException | IOException e) {
                     logger.error("Couldn't parse lang file "+lang);

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/item/CustomModelDataPoly.java
@@ -48,9 +48,7 @@ import net.minecraft.util.Pair;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * The most standard ItemPoly implementation
@@ -261,7 +259,7 @@ public class CustomModelDataPoly implements ItemPoly {
         if (moddedItemModel != null && !moddedItemModel.getOverridesReadOnly().isEmpty()) {
             // The modded item has overrides, we should remove them and use them as basis for the client item model instead
             for (var override : moddedItemModel.getOverridesReadOnly()) {
-                var predicates = new HashMap<>(override.predicates());
+                var predicates = new TreeMap<>(override.predicates());
                 predicates.put("custom_model_data", (float)cmdValue);
                 clientItemModel.getOverrides().add(new JModelOverride(predicates, override.model()));
             }

--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/ResourcePackImplementation.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/ResourcePackImplementation.java
@@ -12,11 +12,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class ResourcePackImplementation implements PolyMcResourcePack {
-    private final Map<String, Map<String, PolyMcAsset>> assets = new HashMap<>();
+    private final Map<String, Map<String, PolyMcAsset>> assets = new TreeMap<>();
     private final Gson gson = new GsonBuilder().enableComplexMapKeySerialization().disableHtmlEscaping().create();
 
     @Override
@@ -26,7 +26,7 @@ public class ResourcePackImplementation implements PolyMcResourcePack {
 
     @Override
     public void setAsset(String namespace, String path, PolyMcAsset asset) {
-        var perNamespaceMap = assets.computeIfAbsent(namespace, (v) -> new HashMap<>());
+        var perNamespaceMap = assets.computeIfAbsent(namespace, (v) -> new TreeMap<>());
         perNamespaceMap.put(path, asset);
     }
 

--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JBlockStateImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JBlockStateImpl.java
@@ -12,9 +12,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 @ApiStatus.Internal
 public class JBlockStateImpl implements JBlockState {
@@ -24,7 +24,7 @@ public class JBlockStateImpl implements JBlockState {
     @SerializedName(value = "credit", alternate = "__comment")
     private String credit;
 
-    public final Map<String, JsonElement> variants = new HashMap<>();
+    public final Map<String, JsonElement> variants = new TreeMap<>();
 
     public JBlockStateImpl() {
     }

--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
@@ -67,7 +67,7 @@ public class JModelImpl implements JModel {
     @Override
     public @NotNull Map<String,String> getTextures() {
         if (this.textures == null) {
-            this.textures = new HashMap<>();
+            this.textures = new TreeMap<>();
         }
         return this.textures;
     }
@@ -91,7 +91,7 @@ public class JModelImpl implements JModel {
     @Override
     public void setDisplay(JModelDisplayType position, JModelDisplay display) {
         if (this.display == null) {
-            this.display = new HashMap<>();
+            this.display = new TreeMap<>();
         }
         this.display.put(position, display);
     }

--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JSoundEventRegistryImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JSoundEventRegistryImpl.java
@@ -14,8 +14,8 @@ import org.jetbrains.annotations.Nullable;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 @ApiStatus.Internal
 public class JSoundEventRegistryImpl implements JSoundEventRegistry {
@@ -23,7 +23,7 @@ public class JSoundEventRegistryImpl implements JSoundEventRegistry {
     private Map<String, JSoundEvent> jsonRepresentation;
 
     public JSoundEventRegistryImpl() {
-        this.jsonRepresentation = new HashMap<>();
+        this.jsonRepresentation = new TreeMap<>();
     }
 
     public JSoundEventRegistryImpl(Map<String,JSoundEvent> jsonRepresentation) {


### PR DESCRIPTION
By using TreeMap instances instead of HashMaps the generated JSON files will always be sorted.
Thanks to this identical inputs will always generate identical resource pack files.

In order for the zip to be identical too, the dates & times should be omitted when generating the zip file.
This is how I generate them on my multiple servers, and it really helps to keep the amount of resource pack reloads low.
(Which people really hate)