### PR TITLE
Try to use the vanilla client item model definition from the client jar

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
@@ -33,6 +33,24 @@ public class JModelImpl implements JModel {
 
     }
 
+    public JModelImpl(JModel clientModel) {
+        this();
+        this.setParent(clientModel.getParent());
+        this.setGuiLight(clientModel.getGuiLight());
+        this.textures = clientModel.getTextures();
+        this.elements = clientModel.getElements();
+
+        for (JModelDisplayType displayType : JModelDisplayType.values()) {
+            JModelDisplay display = clientModel.getDisplay(displayType);
+
+            if (display != null) {
+                this.setDisplay(displayType, display);
+            }
+        }
+
+        this.overrides = clientModel.getOverrides();
+    }
+
     @ApiStatus.Internal
     public static JModelImpl of(InputStream inputStream, @Nullable String name) {
         try (var jsonReader = new JsonReader(new InputStreamReader(inputStream))) {


### PR DESCRIPTION
Try to get the vanilla item model from the client jar.
This way you no longer need the `shield` and `bow` json strings in the code.

The current method also broke certain items, like compasses for example.
Here my custom compass works, but it broke the vanilla compass model:
![afbeelding](https://user-images.githubusercontent.com/755212/174191705-34aa0fef-b59e-478e-8ba4-ffb2f0483c2a.png)
