### PR TITLE
Use vines for climbable blocks

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/block/BlockStateProfile.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/block/BlockStateProfile.java
@@ -28,6 +28,7 @@ import net.minecraft.block.enums.SculkSensorPhase;
 import net.minecraft.block.enums.SlabType;
 import net.minecraft.block.enums.WallShape;
 import net.minecraft.item.HoneycombItem;
+import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.Direction;
 import org.apache.commons.lang3.ArrayUtils;
@@ -79,6 +80,7 @@ public class BlockStateProfile {
     private static final Block[] SNOWY_GRASS_BLOCKS = {Blocks.MYCELIUM, Blocks.PODZOL}; // Snowy mycelium and podzol look the same as snowy grass
     private static final Block[] WATERLOGGED_SLABS = {Blocks.SMOOTH_STONE_SLAB}; // Smooth stone double slabs do not look like regular smooth stone blocks. Therefore, only the waterlogged double slab is available to us.
     private static final Block[] WALL_BLOCKS = {Blocks.COBBLESTONE_WALL, Blocks.MOSSY_COBBLESTONE_WALL, Blocks.BRICK_WALL, Blocks.PRISMARINE_WALL, Blocks.RED_SANDSTONE_WALL, Blocks.MOSSY_STONE_BRICK_WALL, Blocks.GRANITE_WALL, Blocks.STONE_BRICK_WALL, Blocks.NETHER_BRICK_WALL, Blocks.ANDESITE_WALL, Blocks.RED_NETHER_BRICK_WALL, Blocks.SANDSTONE_WALL, Blocks.END_STONE_BRICK_WALL, Blocks.DIORITE_WALL, Blocks.BLACKSTONE_WALL, Blocks.POLISHED_BLACKSTONE_BRICK_WALL, Blocks.POLISHED_BLACKSTONE_WALL, Blocks.COBBLED_DEEPSLATE_WALL, Blocks.POLISHED_DEEPSLATE_WALL, Blocks.DEEPSLATE_TILE_WALL, Blocks.DEEPSLATE_BRICK_WALL};
+    private static final Block[] CLIMBABLE_BLOCKS = {Blocks.CAVE_VINES, Blocks.WEEPING_VINES, Blocks.TWISTING_VINES};
 
     //FILTERS
     private static final Predicate<BlockState> DEFAULT_FILTER = (blockState) -> blockState != blockState.getBlock().getDefaultState();
@@ -109,6 +111,23 @@ public class BlockStateProfile {
     private static final Predicate<BlockState> DOUBLE_SLAB_FILTER = (blockState) -> blockState.get(SlabBlock.TYPE) == SlabType.DOUBLE;
     private static final Predicate<BlockState> WATERLOGGED_SLAB_FILTER = (blockState) -> blockState.get(SlabBlock.TYPE) == SlabType.DOUBLE && blockState.get(SlabBlock.WATERLOGGED);
     private static final Predicate<BlockState> SLAB_FILTER = (blockState) -> blockState.get(SlabBlock.TYPE) != SlabType.DOUBLE;
+    private static final Predicate<BlockState> CLIMBABLE_FILTER = (blockState) -> {
+
+        if (blockState.getBlock() == Blocks.CAVE_VINES) {
+
+            // Don't use any state with age 0
+            if (blockState.get(Properties.AGE_25) == 0) {
+                return false;
+            }
+
+            // Don't use states with berries (they cause block updates on right click)
+            if (blockState.get(CaveVines.BERRIES) == true) {
+                return false;
+            }
+        }
+
+        return DEFAULT_FILTER.test(blockState);
+    };
 
     //ON FIRST REGISTERS
     private static final BiConsumer<Block,PolyRegistry> DEFAULT_ON_FIRST_REGISTER = (block, polyRegistry) -> polyRegistry.registerBlockPoly(block, new SimpleReplacementPoly(block.getDefaultState()));
@@ -124,6 +143,17 @@ public class BlockStateProfile {
         polyRegistry.registerBlockPoly(block, (input) ->
                 input.with(Properties.POWERED, false).with(Properties.DISARMED,false)
         );
+    };
+    private static final BiConsumer<Block,PolyRegistry> CLIMBABLE_ON_FIRST_REGISTER = (block, polyRegistry) -> {
+
+        if (block == Blocks.CAVE_VINES) {
+            polyRegistry.registerBlockPoly(block, (input) ->
+                    // Force the age to be zero, but let the "berries" be whatever it is
+                    input.with(Properties.AGE_25, 0)
+            );
+        } else {
+            polyRegistry.registerBlockPoly(block, new SimpleReplacementPoly(block.getDefaultState()));
+        }
     };
     private static final BiConsumer<Block,PolyRegistry> SMALL_DRIPLEAF_ON_FIRST_REGISTER = (block, polyRegistry) -> polyRegistry.registerBlockPoly(block, input -> {
         if (input.get(TallPlantBlock.HALF) == DoubleBlockHalf.LOWER) {
@@ -215,6 +245,7 @@ public class BlockStateProfile {
 
     //PROFILES
     public static final BlockStateProfile FULL_BLOCK_PROFILE = combine("full blocks", INFESTED_STONE_SUB_PROFILE, /*TNT_SUB_PROFILE,*/ SNOWY_GRASS_SUB_PROFILE, NOTE_BLOCK_SUB_PROFILE, DISPENSER_SUB_PROFILE, BEEHIVE_SUB_PROFILE, WAXED_COPPER_FULLBLOCK_SUB_PROFILE, JUKEBOX_SUB_PROFILE, DOUBLE_SLAB_SUB_PROFILE, TARGET_BLOCK_SUB_PROFILE, WATERLOGGED_SLAB_SUB_PROFILE);
+    public static final BlockStateProfile CLIMBABLE_PROFILE = new BlockStateProfile("climbable blocks", CLIMBABLE_BLOCKS, CLIMBABLE_FILTER, CLIMBABLE_ON_FIRST_REGISTER);
     public static final BlockStateProfile LEAVES_PROFILE = getProfileWithDefaultFilter("leaves", LEAVES_BLOCKS);
     public static final BlockStateProfile NO_COLLISION_WALL_PROFILE = new BlockStateProfile("empty walls", WALL_BLOCKS, WALL_FILTER, WALL_ON_FIRST_REGISTER);
     public static final BlockStateProfile NO_COLLISION_PROFILE = combine("blocks without collisions", KELP_SUB_PROFILE, SAPLING_SUB_PROFILE, SUGARCANE_SUB_PROFILE, /*CAVE_VINES_SUB_PROFILE,*/ TRIPWIRE_SUB_PROFILE, SMALL_DRIPLEAF_SUB_PROFILE, OPEN_FENCE_GATE_PROFILE);
@@ -227,7 +258,6 @@ public class BlockStateProfile {
     public static final BlockStateProfile WAXED_COPPER_STAIR_PROFILE = new BlockStateProfile("waxed copper stair", WAXED_COPPER_STAIR_BLOCKS, ALWAYS_TRUE_FILTER, WAXED_COPPER_ON_FIRST_REGISTER);
     public static final BlockStateProfile SLAB_PROFILE = combine("slab", PETRIFIED_OAK_SLAB_SUB_PROFILE, WAXED_COPPER_SLAB_SUB_PROFILE);
     public static final BlockStateProfile SCULK_SENSOR_PROFILE = new BlockStateProfile("sculk sensor", Blocks.SCULK_SENSOR, SCULK_FILTER, SCULK_SENSOR_ON_FIRST_REGISTER);
-
     //OTHER CODE
     public static BlockStateProfile getProfileWithDefaultFilter(String name, Block[] blocks) {
         return new BlockStateProfile(name, blocks, DEFAULT_FILTER, DEFAULT_ON_FIRST_REGISTER);

--- a/src/main/java/io/github/theepicblock/polymc/impl/generator/BlockPolyGenerator.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/generator/BlockPolyGenerator.java
@@ -180,6 +180,14 @@ public class BlockPolyGenerator {
 
         //=== NO COLLISION BLOCKS ===
         if (collisionShape.isEmpty() && !(moddedState.getBlock() instanceof WallBlock)) {
+
+            try {
+                if (moddedState.isIn(BlockTags.CLIMBABLE)) {
+                    isUniqueCallback.set(true);
+                    return manager.requestBlockState(BlockStateProfile.CLIMBABLE_PROFILE);
+                }
+            } catch (BlockStateManager.StateLimitReachedException ignored) {}
+
             var outlineShape = moddedState.getOutlineShape(fakeWorld, BlockPos.ORIGIN);
 
             if (outlineShape.isEmpty()) {


### PR DESCRIPTION
Before this change, PolyMC would use regular non-collidables. But that of course doesn't make the block climbable:
![afbeelding](https://user-images.githubusercontent.com/755212/174302912-ccdce634-9591-4095-bdee-2ef4929484d9.png)

After this change it'll use vines for this:
![afbeelding](https://user-images.githubusercontent.com/755212/174303057-1f9538ef-bdac-4059-a658-a6692a40d502.png)

Cave vines come first, because they have the biggest hit box.