### PR TITLE
Make the PolyRegistry properties protected instead of private

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/PolyRegistry.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/PolyRegistry.java
@@ -44,13 +44,13 @@ import java.util.*;
  * This eventually gets transformed to an {@link PolyMap}.
  */
 public class PolyRegistry {
-    private final Map<SharedValuesKey<Object>, Object> sharedValues = new HashMap<>();
+    protected final Map<SharedValuesKey<Object>, Object> sharedValues = new HashMap<>();
 
-    private final Map<Item,ItemPoly> itemPolys = new HashMap<>();
-    private final List<ItemTransformer> globalItemPolys = new ArrayList<>();
-    private final Map<Block,BlockPoly> blockPolys = new HashMap<>();
-    private final Map<ScreenHandlerType<?>,GuiPoly> guiPolys = new HashMap<>();
-    private final Map<EntityType<?>,EntityPoly<?>> entityPolys = new HashMap<>();
+    protected final Map<Item,ItemPoly> itemPolys = new HashMap<>();
+    protected final List<ItemTransformer> globalItemPolys = new ArrayList<>();
+    protected final Map<Block,BlockPoly> blockPolys = new HashMap<>();
+    protected final Map<ScreenHandlerType<?>,GuiPoly> guiPolys = new HashMap<>();
+    protected final Map<EntityType<?>,EntityPoly<?>> entityPolys = new HashMap<>();
 
     /**
      * Register a poly for an item.


### PR DESCRIPTION
All the PolyRegistry properties are currently private, that makes it kind of annoying to work with when extending it.

After this change, I'm able to just do:
https://github.com/skerit/polymc-plus/blob/1.19/src/main/java/rocks/blackblock/polymcplus/polymc/PolyPlusRegistry.java

Instead of what I used to have to do:
(Which was basically to duplicate all the code)
https://github.com/skerit/polyvalent/blob/1.18/src/main/java/rocks/blackblock/polyvalent/polymc/PolyvalentRegistry.java