### PR TITLE
Fix ArmorColorManager trying to get the wrong armor textures

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/item/ArmorColorManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/item/ArmorColorManager.java
@@ -100,10 +100,10 @@ public class ArmorColorManager implements SharedValuesKey.ResourceContainer {
 
             // Write vanilla leather
             try {
-                var leatherTexture = ImageIO.read(Objects.requireNonNull(moddedResources.includeClientJar(logger).getInputStream("minecraft", "textures/models/armor/vanilla_leather_layer_" + layer + ".png")));
+                var leatherTexture = ImageIO.read(Objects.requireNonNull(moddedResources.includeClientJar(logger).getInputStream("minecraft", "textures/models/armor/leather_layer_" + layer + ".png")));
                 graphics.drawImage(leatherTexture, 0, 0, null);
 
-                var leatherOverlayTexture = ImageIO.read(Objects.requireNonNull(moddedResources.includeClientJar(logger).getInputStream("minecraft", "textures/models/armor/vanilla_leather_layer_" + layer + "_overlay.png")));
+                var leatherOverlayTexture = ImageIO.read(Objects.requireNonNull(moddedResources.includeClientJar(logger).getInputStream("minecraft", "textures/models/armor/leather_layer_" + layer + "_overlay.png")));
                 graphics.drawImage(leatherOverlayTexture, 0, 0, null);
             } catch (Exception e) {
                 logger.error("Error reading vanilla armor textures, please report this");


### PR DESCRIPTION
`ArmorColorManager` was still trying to get the texture files as they used to be named in the PolyMC's internal resources.
Just had to drop the `vanilla_` prefix.