### PR TITLE
Only send custom BlockBreakingProgress packet for modded blocks

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/BlockBreakingPatch.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/BlockBreakingPatch.java
@@ -84,8 +84,10 @@ public abstract class BlockBreakingPatch {
 
     @Inject(method = "continueMining", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, shift = At.Shift.AFTER, target = "Lnet/minecraft/server/network/ServerPlayerInteractionManager;blockBreakingProgress:I"))
     public void onUpdateBreakStatus(BlockState state, BlockPos pos, int i, CallbackInfoReturnable<Float> cir) {
-        //Send a packet that resembles the current mining progress
-        player.networkHandler.sendPacket(new BlockBreakingProgressS2CPacket(-1, pos, this.blockBreakingProgress));
+        if (CustomBlockBreakingCheck.needsCustomBreaking(player, state.getBlock())) {
+            //Send a packet that resembles the current mining progress
+            player.networkHandler.sendPacket(new BlockBreakingProgressS2CPacket(-1, pos, this.blockBreakingProgress));
+        }
     }
 
     @Inject(method = "processBlockBreakingAction", at = @At("HEAD"))


### PR DESCRIPTION
The current implementation (which was changed in commit 8677acc9) sends a `BlockBreakingProgressS2CPacket` for every block, not just modded blocks.

This causes the block breaking progress texture to stick around on vanilla blocks.

Just one `CustomBlockBreakingCheck.needsCustomBreaking` check fixes this.