### PR TITLE
Upgrade to 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-	id 'fabric-loom' version '1.1-SNAPSHOT'
+	id 'fabric-loom' version '1.2-SNAPSHOT'
 	id 'maven-publish'
 	id 'io.github.juuxel.loom-quiltflower' version '1.8.+'
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = "${project.mod_version}${getVersionMetadata()}+${project.minecraft_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
-	id 'io.github.juuxel.loom-quiltflower' version '1.7.1'
+	id 'io.github.juuxel.loom-quiltflower' version '1.8.+'
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,20 +3,20 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.1
-	loader_version=0.14.12
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.2
+	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 5.3.2
+	mod_version = 5.4.0
 	maven_group = nl.theepicblock
 	archives_base_name = PolyMc
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.68.1+1.19.3
-	qsl_version=4.0.0-beta.5+1.19.3
-	lithium_version=mc1.19.2-0.10.1
+	fabric_version=0.83.0+1.19.4
+	qsl_version=5.0.0-beta.10+1.19.4
+	lithium_version=mc1.19.4-0.11.1
 	immersive_portals_version=v1.3.3-1.18
 	resource_locator_api_version=0.4.1+1.19.3
-	packet_tweaker_version=0.3.0+1.18.2
+	packet_tweaker_version=0.4.0+1.19.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Jun 06 17:17:18 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/theepicblock/polymc/api/wizard/PacketConsumer.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/wizard/PacketConsumer.java
@@ -1,6 +1,6 @@
 package io.github.theepicblock.polymc.api.wizard;
 
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import org.jetbrains.annotations.ApiStatus;
 
 public interface PacketConsumer {

--- a/src/main/java/io/github/theepicblock/polymc/impl/misc/FakeWorld.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/misc/FakeWorld.java
@@ -206,6 +206,7 @@ public final class FakeWorld extends World {
             worldDefault = new FakeWorld(
                     new FakeWorldProperties(),
                     RegistryKey.of(RegistryKeys.WORLD, new Identifier("polymer", "fake_world")),
+                    null,
                     dimType,
                     () -> new ProfilerSystem(() -> 0l, () -> 0, false),
                     false,
@@ -225,8 +226,8 @@ public final class FakeWorld extends World {
         INSTANCE = worldUnsafe != null ? worldUnsafe : worldDefault;
     }
 
-    protected FakeWorld(MutableWorldProperties properties, RegistryKey<World> registryRef, RegistryEntry<DimensionType> dimensionType, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed) {
-        super(properties, registryRef, dimensionType, profiler, isClient, debugWorld, seed, 0);
+    protected FakeWorld(MutableWorldProperties properties, RegistryKey<World> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionType, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed) {
+        super(properties, registryRef, registryManager, dimensionType, profiler, isClient, debugWorld, seed, 0);
     }
 
     @Override

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/CachedPolyMapFilteredPlayerView.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/CachedPolyMapFilteredPlayerView.java
@@ -2,7 +2,7 @@ package io.github.theepicblock.polymc.impl.poly.wizard;
 
 import io.github.theepicblock.polymc.api.PolyMap;
 import io.github.theepicblock.polymc.api.misc.PolyMapProvider;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.ArrayList;

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/PacketCountManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/PacketCountManager.java
@@ -7,7 +7,7 @@ import io.github.theepicblock.polymc.impl.ConfigManager;
 import io.github.theepicblock.polymc.mixins.TACSAccessor;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.EntityTrackingListener;

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/PolyMapFilteredPlayerView.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/PolyMapFilteredPlayerView.java
@@ -2,7 +2,7 @@ package io.github.theepicblock.polymc.impl.poly.wizard;
 
 import io.github.theepicblock.polymc.api.PolyMap;
 import io.github.theepicblock.polymc.api.misc.PolyMapProvider;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/SinglePlayerView.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/poly/wizard/SinglePlayerView.java
@@ -1,6 +1,6 @@
 package io.github.theepicblock.polymc.impl.poly.wizard;
 
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 public class SinglePlayerView extends AbstractPacketConsumer {

--- a/src/main/java/io/github/theepicblock/polymc/mixins/CustomPacketDisabler.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/CustomPacketDisabler.java
@@ -18,7 +18,7 @@
 package io.github.theepicblock.polymc.mixins;
 
 import io.github.theepicblock.polymc.impl.Util;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
@@ -34,7 +34,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class CustomPacketDisabler {
     @Shadow public ServerPlayerEntity player;
 
-    @Inject(method = "sendPacket(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V", at = @At("HEAD"), cancellable = true)
     public void sendPacketInject(Packet<?> packet, PacketCallbacks callbacks, CallbackInfo ci) {
         if (packet instanceof CustomPayloadS2CPacket && Util.isPolyMapVanillaLike(this.player)) {
             Identifier channel = ((CustomPacketAccessor)packet).getChannel();

--- a/src/main/java/io/github/theepicblock/polymc/mixins/DisableCustomParticles.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/DisableCustomParticles.java
@@ -1,7 +1,7 @@
 package io.github.theepicblock.polymc.mixins;
 
 import io.github.theepicblock.polymc.impl.Util;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.s2c.play.ParticleS2CPacket;
 import net.minecraft.registry.Registries;
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class DisableCustomParticles {
     @Shadow public ServerPlayerEntity player;
 
-    @Inject(method = "sendPacket(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V", at = @At("HEAD"), cancellable = true)
     private void sendPacketInject(Packet<?> packet, PacketCallbacks callbacks, CallbackInfo ci) {
         if (packet instanceof ParticleS2CPacket particlePacket && Util.isPolyMapVanillaLike(this.player)) {
             var effect = particlePacket.getParameters();

--- a/src/main/java/io/github/theepicblock/polymc/mixins/SoundPacketFix.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/SoundPacketFix.java
@@ -1,7 +1,7 @@
 package io.github.theepicblock.polymc.mixins;
 
 import io.github.theepicblock.polymc.impl.Util;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.SoundEvent;

--- a/src/main/java/io/github/theepicblock/polymc/mixins/block/FixLighting.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/block/FixLighting.java
@@ -2,7 +2,7 @@ package io.github.theepicblock.polymc.mixins.block;
 
 import io.github.theepicblock.polymc.impl.Util;
 import io.github.theepicblock.polymc.mixins.TACSAccessor;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.util.math.ChunkPos;
 import org.spongepowered.asm.mixin.Final;
@@ -27,7 +27,7 @@ public abstract class FixLighting {
      *
      * @see net.minecraft.server.world.ThreadedAnvilChunkStorage#getPlayersWatchingChunk(ChunkPos, boolean)
      */
-    @Redirect(method = "flushUpdates(Lnet/minecraft/world/chunk/WorldChunk;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;sendPacketToPlayersWatching(Lnet/minecraft/network/Packet;Z)V"))
+    @Redirect(method = "flushUpdates(Lnet/minecraft/world/chunk/WorldChunk;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;sendPacketToPlayersWatching(Lnet/minecraft/network/packet/Packet;Z)V"))
     private void onSendLightUpdates(ChunkHolder chunkHolder, Packet<?> packet, boolean onlyOnWatchDistanceEdge) {
         if (onlyOnWatchDistanceEdge == false) {
             // This will be sent to everyone regardless. Just use the normal method

--- a/src/main/java/io/github/theepicblock/polymc/mixins/compat/QuiltFabricRegistrySyncDisabler.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/compat/QuiltFabricRegistrySyncDisabler.java
@@ -3,7 +3,7 @@ package io.github.theepicblock.polymc.mixins.compat;
 import io.github.theepicblock.polymc.impl.Util;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
-import org.quiltmc.qsl.registry.impl.sync.ServerFabricRegistrySync;
+import org.quiltmc.qsl.registry.impl.sync.server.ServerFabricRegistrySync;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerFabricRegistrySync.class)
 public class QuiltFabricRegistrySyncDisabler {
+    /*
     @SuppressWarnings("MixinAnnotationTarget")
     @Inject(method = "sendSyncPackets(Lnet/minecraft/network/ClientConnection;)V", at = @At("HEAD"), cancellable = true)
     private static void sendPacketInject(ClientConnection connection, CallbackInfo ci) {
@@ -19,4 +20,5 @@ public class QuiltFabricRegistrySyncDisabler {
             ci.cancel();
         }
     }
+    */
 }

--- a/src/main/java/io/github/theepicblock/polymc/mixins/compat/QuiltRegistrySyncDisabler.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/compat/QuiltRegistrySyncDisabler.java
@@ -4,7 +4,7 @@ import io.github.theepicblock.polymc.api.misc.PolyMapProvider;
 import io.github.theepicblock.polymc.impl.Util;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.network.ServerPlayerEntity;
-import org.quiltmc.qsl.registry.impl.sync.ServerRegistrySync;
+import org.quiltmc.qsl.registry.impl.sync.server.ServerRegistrySync;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerRegistrySync.class)
 public class QuiltRegistrySyncDisabler {
+    /*
     @SuppressWarnings("MixinAnnotationTarget")
     @Inject(method = "sendSyncPackets(Lnet/minecraft/network/ClientConnection;Lnet/minecraft/server/network/ServerPlayerEntity;I)V", at = @At("HEAD"), cancellable = true)
     private static void sendPacketInject(ClientConnection connection, ServerPlayerEntity player, int syncVersion, CallbackInfo ci) {
@@ -20,4 +21,5 @@ public class QuiltRegistrySyncDisabler {
             ci.cancel();
         }
     }
+    */
 }

--- a/src/main/java/io/github/theepicblock/polymc/mixins/entity/DisableCustomEntities.java
+++ b/src/main/java/io/github/theepicblock/polymc/mixins/entity/DisableCustomEntities.java
@@ -2,7 +2,8 @@ package io.github.theepicblock.polymc.mixins.entity;
 
 import io.github.theepicblock.polymc.api.misc.PolyMapProvider;
 import io.github.theepicblock.polymc.impl.mixin.EntityTrackerEntryDuck;
-import net.minecraft.network.Packet;
+import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,7 @@ import java.util.function.Consumer;
 @Mixin(EntityTrackerEntry.class)
 public class DisableCustomEntities {
     @Redirect(method = "startTracking", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/EntityTrackerEntry;sendPackets(Ljava/util/function/Consumer;)V"))
-    public void polymc$maybeBlockSpawnPacket(EntityTrackerEntry instance, Consumer<Packet<?>> sender, ServerPlayerEntity player) {
+    public void polymc$maybeBlockSpawnPacket(EntityTrackerEntry instance, Consumer<Packet<ClientPlayPacketListener>> sender, ServerPlayerEntity player) {
         if (((EntityTrackerEntryDuck)this).polymc$getWizards().get(PolyMapProvider.getPolyMap(player)) == null) {
             instance.sendPackets(sender);
         }


### PR DESCRIPTION
Not a lot of changes were needed to make PolyMc work with 1.19.4, just that `Packet` moved to its own `packet` package.

I still couldn't get the Quilt mixins to work as you can see, so I commented them out :grimacing: 
Even with `remap=false` and `@Coerce` it failed.