### PR TITLE
Small compatibility changes

### DIFF
--- a/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataManager.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/item/CustomModelDataManager.java
@@ -56,14 +56,14 @@ public class CustomModelDataManager {
             Items.DIAMOND,
             Items.NETHERITE_SCRAP,
             Items.NETHERITE_INGOT,
-            Items.HEART_OF_THE_SEA,
+            Items.PRISMARINE_CRYSTALS,
             Items.NAUTILUS_SHELL,
             Items.PHANTOM_MEMBRANE,
             Items.ECHO_SHARD,
             Items.GUNPOWDER,
             Items.SUGAR,
             Items.BLAZE_ROD,
-            Items.PAPER,
+            Items.PAPER
     };
     public final static Item[] FUEL_ITEMS = {
             Items.COAL,

--- a/src/main/java/io/github/theepicblock/polymc/api/resource/json/JElementFace.java
+++ b/src/main/java/io/github/theepicblock/polymc/api/resource/json/JElementFace.java
@@ -1,5 +1,6 @@
 package io.github.theepicblock.polymc.api.resource.json;
 
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -8,10 +9,10 @@ public final class JElementFace {
     private final double[] uv;
     private final String texture;
     private final JDirection cullface;
-    private final int rotation;
-    private final int tintindex;
+    private final Integer rotation;
+    private final Integer tintindex;
 
-    public JElementFace(double[] uv, String texture, JDirection cullface, int rotation, int tintindex) {
+    public JElementFace(double[] uv, String texture, JDirection cullface, @Nullable Integer rotation, @Nullable Integer tintindex) {
         this.uv = uv;
         this.texture = texture;
         this.cullface = cullface;
@@ -31,11 +32,11 @@ public final class JElementFace {
         return cullface;
     }
 
-    public int rotation() {
+    public Integer rotation() {
         return rotation;
     }
 
-    public int tintindex() {
+    public Integer tintindex() {
         return tintindex;
     }
 
@@ -44,12 +45,22 @@ public final class JElementFace {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JElementFace that = (JElementFace)o;
-        return rotation == that.rotation && tintindex == that.tintindex && Arrays.equals(uv, that.uv) && Objects.equals(texture, that.texture) && cullface == that.cullface;
+        return (rotation == null || that.rotation == null) ? rotation == that.rotation : rotation.intValue() == that.rotation.intValue() &&
+                (tintindex == null || that.tintindex == null) ? tintindex == that.tintindex : tintindex.intValue() == that.tintindex.intValue() &&
+                Arrays.equals(uv, that.uv) && Objects.equals(texture, that.texture) && cullface == that.cullface;
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(texture, cullface, rotation, tintindex);
+        int result;
+        if (tintindex != null) {
+            if (rotation != null) result = Objects.hash(texture, cullface, rotation, tintindex);
+            else result = Objects.hash(texture, cullface, tintindex);
+        }
+        else {
+            if (rotation != null) result = Objects.hash(texture, cullface, rotation);
+            else result = Objects.hash(texture, cullface);
+        }
         result = 31 * result + Arrays.hashCode(uv);
         return result;
     }

--- a/src/main/java/io/github/theepicblock/polymc/impl/PolyMapImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/PolyMapImpl.java
@@ -112,6 +112,7 @@ public class PolyMapImpl implements PolyMap {
         if ((player == null || player.isCreative() || location == ItemLocation.CREATIVE || this.ALWAYS_ADD_CREATIVE_NBT) && !ItemStack.canCombine(serverItem, ret) && !serverItem.isEmpty()) {
             // Preserves the nbt of the original item, so it can be reverted
             ret = ret.copy();
+            originalNbt.remove("Count");
             ret.setSubNbt(ORIGINAL_ITEM_NBT, originalNbt);
         }
 

--- a/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
+++ b/src/main/java/io/github/theepicblock/polymc/impl/resource/json/JModelImpl.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
+import io.github.theepicblock.polymc.PolyMc;
 import io.github.theepicblock.polymc.api.resource.json.*;
 import io.github.theepicblock.polymc.impl.Util;
 import io.github.theepicblock.polymc.impl.resource.ResourceGenerationException;
@@ -23,6 +24,35 @@ public class JModelImpl implements JModel {
      */
     @SerializedName(value = "credit", alternate = "__comment")
     private String credit;
+
+    /**
+     * Ordered list keeps track of model predicate priority when sorting.
+     * Note that ranged numbers (0-1) take priority over boolean values.
+     */
+    protected static final String[] MODEL_PREDICATES = new String[]{
+        "custom_model_data",
+        "angle",
+        "damage",
+        "pull",
+        "time",
+        "trim_type",
+        "brushing",
+
+        "blocking",
+        "broken",
+        "cast",
+        "cooldown",
+        "damaged",
+        "lefthanded",
+        "pulling",
+        "charged",
+        "firework",
+        "throwing",
+        "level",
+        "filled",
+        "tooting",
+        "level"
+    };
 
     public String parent;
     public JGuiLight gui_light;
@@ -117,10 +147,25 @@ public class JModelImpl implements JModel {
     private void sortOverrides() {
         if (overrides == null) return;
         overrides.sort((o1, o2) -> {
-            if (o1.predicates().size() > 0 && o2.predicates().size() > 0) {
-                double i1 = o1.predicates().values().iterator().next();
-                double i2 = o2.predicates().values().iterator().next();
-                return (int)(i1 - i2);
+            // For each predicate listed in the ordered priority list, weigh the overrides against each other.
+            for (String predictae_name : MODEL_PREDICATES) {
+                boolean o1_has_predicate = o1.predicates().containsKey(predictae_name);
+                boolean o2_has_predicate = o2.predicates().containsKey(predictae_name);
+
+                // If neither model has the predicate, then continue.
+                if (!o1_has_predicate && !o2_has_predicate)
+                    continue;
+
+                // If one model has the predicate but the other doesn't, put the lacking one on top.
+                if (!o1_has_predicate || !o2_has_predicate)
+                    return o1_has_predicate ? 0 : -1;
+
+                // Weigh the values of each. If they are equal, continue.
+                double i1 = o1.predicates().get(predictae_name);
+                double i2 = o2.predicates().get(predictae_name);
+                double difference = i1 - i2;
+                // Using math.abs to account for double precision errors
+                if (Math.abs(difference) > 0.0001) return (int)difference;
             }
             return 0;
         });


### PR DESCRIPTION
Hello! I've been working with PolyMc with Skerit for about 2 and a half months now and here implemented two changes I find necessary.

The first is a change with the GSON item & block model reader to make the `rotation` and `tintindex` tags optional and thus not put into every file. I found this necessary as I was having troubles implementing DyeableItems that had only some parts of it dyeable (the `tintindex: 0` tags everywhere made the whole thing colored regardless of what I fed into it).

The second change is one I found necessary because I was making an item that had an override to `BlockItem.getTranslationKey` and the Heart of the Sea item was having its rarity poke through and make the name yellow. I found it simpler to just swap it out with a different item rather than chase down the cause of that bug.